### PR TITLE
Updated cloud protocol service to always use https

### DIFF
--- a/dialogs/wsc.js
+++ b/dialogs/wsc.js
@@ -1848,8 +1848,7 @@ CKEDITOR.dialog.add('checkspell', function(editor) {
 				NS.cust_dic_ids = editor.config.wsc_customDictionaryIds;
 				NS.userDictionaryName = editor.config.wsc_userDictionaryName;
 				NS.defaultLanguage = CKEDITOR.config.defaultLanguage;
-				var	protocol = document.location.protocol == "file:" ? "http:" : document.location.protocol;
-				var wscCoreUrl = editor.config.wsc_customLoaderScript  || ( protocol + '//www.webspellchecker.net/spellcheck31/lf/22/js/wsc_fck2plugin.js');
+				var wscCoreUrl = editor.config.wsc_customLoaderScript || 'https://www.webspellchecker.net/spellcheck31/lf/22/js/wsc_fck2plugin.js';
 			} else {
 				NS.dialog.hide();
 				return;

--- a/dialogs/wsc_ie.js
+++ b/dialogs/wsc_ie.js
@@ -9,7 +9,6 @@ CKEDITOR.dialog.add( 'checkspell', function( editor ) {
 		textareaId = 'cke_data_' + number,
 		errorBoxId = 'cke_error_' + number,
 		interval,
-		protocol = document.location.protocol || 'http:',
 		errorMsg = editor.lang.wsc.notAvailable;
 
 	var pasteArea =
@@ -30,7 +29,7 @@ CKEDITOR.dialog.add( 'checkspell', function( editor ) {
 			' allowtransparency="1">' +
 		'</iframe>';
 
-	var wscCoreUrl = editor.config.wsc_customLoaderScript || ( protocol + '//loader.webspellchecker.net/sproxy_fck/sproxy.php' + '?plugin=fck2'
+	var wscCoreUrl = editor.config.wsc_customLoaderScript || ( 'https://loader.webspellchecker.net/sproxy_fck/sproxy.php' + '?plugin=fck2'
 		+ '&customerid=' + editor.config.wsc_customerId
 		+ '&cmd=script&doc=wsc&schema=22'
 	);


### PR DESCRIPTION
Similar to https://github.com/WebSpellChecker/ckeditor-plugin-scayt/pull/185 I've updated WSC protocols.

I've just updated protocol and left the rest of the link untouched, but we've also got the `https://svc.webspellchecker.net/spellcheck/lf/22/js/wsc_fck2plugin.js` URL on Slack from you, so I'm not sure which one is correct.

I've also couldn't check if the change works correctly on IE, as I don't have access to an authorized domain on Windows.